### PR TITLE
Preconfigured Tracepoint-Specific Logger Operations

### DIFF
--- a/json-logger/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerOperations.java
+++ b/json-logger/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerOperations.java
@@ -7,7 +7,19 @@ import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.joda.time.DateTime;
 import org.mule.extension.jsonlogger.api.pojos.LoggerProcessor;
+import org.mule.extension.jsonlogger.api.pojos.LoggerProcessorAfter;
+import org.mule.extension.jsonlogger.api.pojos.LoggerProcessorBefore;
+import org.mule.extension.jsonlogger.api.pojos.LoggerProcessorStart;
+import org.mule.extension.jsonlogger.api.pojos.LoggerProcessorError;
+import org.mule.extension.jsonlogger.api.pojos.LoggerProcessorEnd;
+import org.mule.extension.jsonlogger.api.pojos.LoggerProcessorFlow;
 import org.mule.extension.jsonlogger.api.pojos.Priority;
+import org.mule.extension.jsonlogger.api.pojos.AfterPriority;
+import org.mule.extension.jsonlogger.api.pojos.BeforePriority;
+import org.mule.extension.jsonlogger.api.pojos.FlowPriority;
+import org.mule.extension.jsonlogger.api.pojos.TracePoint;
+import org.mule.extension.jsonlogger.api.pojos.AfterTracePoint;
+import org.mule.extension.jsonlogger.api.pojos.BeforeTracePoint;
 import org.mule.extension.jsonlogger.api.pojos.ScopeTracePoint;
 import org.mule.extension.jsonlogger.internal.datamask.JsonMasker;
 import org.mule.extension.jsonlogger.internal.singleton.ConfigsSingleton;
@@ -233,6 +245,138 @@ public class JsonloggerOperations {
             LOGGER.debug("Avoiding logger operation logic execution due to log priority not being enabled");
         }
         callback.success(VOID_RESULT);
+    }
+
+    /**
+     * Log the START tracepoint at INFO level
+     */
+    @Execution(ExecutionType.BLOCKING)
+    public void logStart(@ParameterGroup(name = "Logger") @Expression(value = NOT_SUPPORTED) LoggerProcessorStart loggerProcessorStart,
+                       CorrelationInfo correlationInfo,
+                       ComponentLocation location,
+                       @Config JsonloggerConfiguration config,
+                       FlowListener flowListener,
+                       CompletionCallback<Void, Void> callback) {
+            
+        LoggerProcessor loggerProcessor = new LoggerProcessor();
+        loggerProcessor.setCorrelationId(loggerProcessorStart.getCorrelationId());
+        loggerProcessor.setMessage(loggerProcessorStart.getMessage());
+        loggerProcessor.setContent(loggerProcessorStart.getContent());
+        loggerProcessor.setCategory(loggerProcessorStart.getCategory());
+        loggerProcessor.setContent(loggerProcessorStart.getContent());
+        loggerProcessor.setTracePoint(TracePoint.START);
+        loggerProcessor.setPriority(Priority.INFO);
+        logger(loggerProcessor, correlationInfo, location, config, flowListener, callback);
+    }
+
+    /**
+     * Log the END tracepoint at the INFO level
+     */
+    @Execution(ExecutionType.BLOCKING)
+    public void logEnd(@ParameterGroup(name = "Logger") @Expression(value = NOT_SUPPORTED) LoggerProcessorEnd loggerProcessorEnd,
+                       CorrelationInfo correlationInfo,
+                       ComponentLocation location,
+                       @Config JsonloggerConfiguration config,
+                       FlowListener flowListener,
+                       CompletionCallback<Void, Void> callback) {
+            
+        LoggerProcessor loggerProcessor = new LoggerProcessor();
+        loggerProcessor.setCorrelationId(loggerProcessorEnd.getCorrelationId());
+        loggerProcessor.setMessage(loggerProcessorEnd.getMessage());
+        loggerProcessor.setContent(loggerProcessorEnd.getContent());
+        loggerProcessor.setCategory(loggerProcessorEnd.getCategory());
+        loggerProcessor.setContent(loggerProcessorEnd.getContent());
+        loggerProcessor.setTracePoint(TracePoint.END);
+        loggerProcessor.setPriority(Priority.INFO);
+        logger(loggerProcessor, correlationInfo, location, config, flowListener, callback);
+    }
+
+    /**
+     * Log the BEFORE tracepoint
+     */
+    @Execution(ExecutionType.BLOCKING)
+    public void logBefore(@ParameterGroup(name = "Logger") @Expression(value = NOT_SUPPORTED) LoggerProcessorBefore loggerProcessorBefore,
+                       CorrelationInfo correlationInfo,
+                       ComponentLocation location,
+                       @Config JsonloggerConfiguration config,
+                       FlowListener flowListener,
+                       CompletionCallback<Void, Void> callback) {
+            
+        LoggerProcessor loggerProcessor = new LoggerProcessor();
+        loggerProcessor.setCorrelationId(loggerProcessorBefore.getCorrelationId());
+        loggerProcessor.setMessage(loggerProcessorBefore.getMessage());
+        loggerProcessor.setContent(loggerProcessorBefore.getContent());
+        loggerProcessor.setCategory(loggerProcessorBefore.getCategory());
+        loggerProcessor.setContent(loggerProcessorBefore.getContent());
+        loggerProcessor.setTracePoint(TracePoint.valueOf(loggerProcessorBefore.getTracePoint().toString()));
+        loggerProcessor.setPriority(Priority.valueOf(loggerProcessorBefore.getPriority().toString()));
+        logger(loggerProcessor, correlationInfo, location, config, flowListener, callback);
+    }
+
+    /**
+     * Log the AFTER tracepoint
+     */
+    @Execution(ExecutionType.BLOCKING)
+    public void logAfter(@ParameterGroup(name = "Logger") @Expression(value = NOT_SUPPORTED) LoggerProcessorAfter loggerProcessorAfter,
+                       CorrelationInfo correlationInfo,
+                       ComponentLocation location,
+                       @Config JsonloggerConfiguration config,
+                       FlowListener flowListener,
+                       CompletionCallback<Void, Void> callback) {
+            
+        LoggerProcessor loggerProcessor = new LoggerProcessor();
+        loggerProcessor.setCorrelationId(loggerProcessorAfter.getCorrelationId());
+        loggerProcessor.setMessage(loggerProcessorAfter.getMessage());
+        loggerProcessor.setContent(loggerProcessorAfter.getContent());
+        loggerProcessor.setCategory(loggerProcessorAfter.getCategory());
+        loggerProcessor.setContent(loggerProcessorAfter.getContent());
+        loggerProcessor.setTracePoint(TracePoint.valueOf(loggerProcessorAfter.getTracePoint().toString()));
+        loggerProcessor.setPriority(Priority.valueOf(loggerProcessorAfter.getPriority().toString()));
+        logger(loggerProcessor, correlationInfo, location, config, flowListener, callback);
+    }
+
+    /**
+     * Log the EXCEPTION tracepoint at the ERROR level
+     */
+    @Execution(ExecutionType.BLOCKING)
+    public void logError(@ParameterGroup(name = "Logger") @Expression(value = NOT_SUPPORTED) LoggerProcessorError loggerProcessorError,
+                       CorrelationInfo correlationInfo,
+                       ComponentLocation location,
+                       @Config JsonloggerConfiguration config,
+                       FlowListener flowListener,
+                       CompletionCallback<Void, Void> callback) {
+            
+        LoggerProcessor loggerProcessor = new LoggerProcessor();
+        loggerProcessor.setCorrelationId(loggerProcessorError.getCorrelationId());
+        loggerProcessor.setMessage(loggerProcessorError.getMessage());
+        loggerProcessor.setContent(loggerProcessorError.getContent());
+        loggerProcessor.setCategory(loggerProcessorError.getCategory());
+        loggerProcessor.setContent(loggerProcessorError.getContent());
+        loggerProcessor.setTracePoint(TracePoint.EXCEPTION);
+        loggerProcessor.setPriority(Priority.ERROR);
+        logger(loggerProcessor, correlationInfo, location, config, flowListener, callback);
+    }
+
+    /**
+     * Log the FLOW tracepoint
+     */
+    @Execution(ExecutionType.BLOCKING)
+    public void logFlow(@ParameterGroup(name = "Logger") @Expression(value = NOT_SUPPORTED) LoggerProcessorFlow loggerProcessorFlow,
+                       CorrelationInfo correlationInfo,
+                       ComponentLocation location,
+                       @Config JsonloggerConfiguration config,
+                       FlowListener flowListener,
+                       CompletionCallback<Void, Void> callback) {
+            
+        LoggerProcessor loggerProcessor = new LoggerProcessor();
+        loggerProcessor.setCorrelationId(loggerProcessorFlow.getCorrelationId());
+        loggerProcessor.setMessage(loggerProcessorFlow.getMessage());
+        loggerProcessor.setContent(loggerProcessorFlow.getContent());
+        loggerProcessor.setCategory(loggerProcessorFlow.getCategory());
+        loggerProcessor.setContent(loggerProcessorFlow.getContent());
+        loggerProcessor.setTracePoint(TracePoint.FLOW);
+        loggerProcessor.setPriority(Priority.valueOf(loggerProcessorFlow.getPriority().toString()));
+        logger(loggerProcessor, correlationInfo, location, config, flowListener, callback);
     }
 
     /**

--- a/json-logger/src/main/resources/schema/loggerProcessorAfter.json
+++ b/json-logger/src/main/resources/schema/loggerProcessorAfter.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Definition for fields used in the logger message processor",
+  "type": "object",
+  "properties": {
+    "correlationId": {
+      "type": "string",
+      "sdk": {
+        "default": "#[correlationId]",
+        "placement": {
+          "tab": "Advanced"
+        }
+      }
+    },
+    "message": {
+      "type": "string",
+      "sdk": {
+        "example": "Add a log message",
+        "required": false,
+        "summary": "Message to be logged"
+      }
+    },
+    "content": {
+      "type": "string",
+      "javaType": "org.mule.runtime.extension.api.runtime.parameter.ParameterResolver<org.mule.runtime.api.metadata.TypedValue<java.io.InputStream>>",
+      "sdk": {
+        "default": "#[import modules::JSONLoggerModule output application/json ---\n{\n    payload: JSONLoggerModule::stringifyNonJSON(payload) \n}]",
+        "summary": "NOTE: Writing the entire payload every time across your application can cause serious performance issues",
+        "required": false,
+        "isContent": true
+      }
+    },
+    "tracePoint": {
+      "type": "string",
+      "javaType": "org.mule.extension.jsonlogger.api.pojos.AfterTracePoint",
+      "enum": [
+        "AFTER_TRANSFORM",
+        "AFTER_REQUEST"
+      ],
+      "sdk": {
+        "default": "AFTER_REQUEST",
+        "summary": "Current processing stage"
+      }
+    },
+    "priority": {
+      "type": "string",
+      "javaType": "org.mule.extension.jsonlogger.api.pojos.AfterPriority",
+      "enum": [
+        "DEBUG",
+        "TRACE",
+        "INFO"
+      ],
+      "sdk": {
+        "default": "DEBUG",
+        "summary": "Logger priority"
+      },
+      "note": "This field is mandatory. DON'T REMOVE"
+    },
+    "category": {
+      "type": "string",
+      "sdk": {
+        "required": false,
+        "summary": "If not set, by default will log to the org.mule.extension.jsonlogger.JsonLogger category"
+      },
+      "note": "This field is mandatory. DON'T REMOVE"
+    }
+  }
+}

--- a/json-logger/src/main/resources/schema/loggerProcessorBefore.json
+++ b/json-logger/src/main/resources/schema/loggerProcessorBefore.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Definition for fields used in the logger message processor",
+  "type": "object",
+  "properties": {
+    "correlationId": {
+      "type": "string",
+      "sdk": {
+        "default": "#[correlationId]",
+        "placement": {
+          "tab": "Advanced"
+        }
+      }
+    },
+    "message": {
+      "type": "string",
+      "sdk": {
+        "example": "Add a log message",
+        "required": false,
+        "summary": "Message to be logged"
+      }
+    },
+    "content": {
+      "type": "string",
+      "javaType": "org.mule.runtime.extension.api.runtime.parameter.ParameterResolver<org.mule.runtime.api.metadata.TypedValue<java.io.InputStream>>",
+      "sdk": {
+        "default": "#[import modules::JSONLoggerModule output application/json ---\n{\n    payload: JSONLoggerModule::stringifyNonJSON(payload) \n}]",
+        "summary": "NOTE: Writing the entire payload every time across your application can cause serious performance issues",
+        "required": false,
+        "isContent": true
+      }
+    },
+    "tracePoint": {
+      "type": "string",
+      "javaType": "org.mule.extension.jsonlogger.api.pojos.BeforeTracePoint",
+      "enum": [
+        "BEFORE_TRANSFORM",
+        "BEFORE_REQUEST"
+      ],
+      "sdk": {
+        "default": "BEFORE_REQUEST",
+        "summary": "Current processing stage"
+      }
+    },
+    "priority": {
+      "type": "string",
+      "javaType": "org.mule.extension.jsonlogger.api.pojos.BeforePriority",
+      "enum": [
+        "DEBUG",
+        "TRACE",
+        "INFO"
+      ],
+      "sdk": {
+        "default": "DEBUG",
+        "summary": "Logger priority"
+      },
+      "note": "This field is mandatory. DON'T REMOVE"
+    },
+    "category": {
+      "type": "string",
+      "sdk": {
+        "required": false,
+        "summary": "If not set, by default will log to the org.mule.extension.jsonlogger.JsonLogger category"
+      },
+      "note": "This field is mandatory. DON'T REMOVE"
+    }
+  }
+}

--- a/json-logger/src/main/resources/schema/loggerProcessorEnd.json
+++ b/json-logger/src/main/resources/schema/loggerProcessorEnd.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Definition for fields used in the logger message processor",
+  "type": "object",
+  "properties": {
+    "correlationId": {
+      "type": "string",
+      "sdk": {
+        "default": "#[correlationId]",
+        "placement": {
+          "tab": "Advanced"
+        }
+      }
+    },
+    "message": {
+      "type": "string",
+      "sdk": {
+        "example": "Add a log message",
+        "required": false,
+        "summary": "Message to be logged"
+      }
+    },
+    "content": {
+      "type": "string",
+      "javaType": "org.mule.runtime.extension.api.runtime.parameter.ParameterResolver<org.mule.runtime.api.metadata.TypedValue<java.io.InputStream>>",
+      "sdk": {
+        "default": "#[import modules::JSONLoggerModule output application/json ---\n{\n    payload: JSONLoggerModule::stringifyNonJSON(payload) \n}]",
+        "summary": "NOTE: Writing the entire payload every time across your application can cause serious performance issues",
+        "required": false,
+        "isContent": true
+      }
+    },
+    "category": {
+      "type": "string",
+      "sdk": {
+        "required": false,
+        "summary": "If not set, by default will log to the org.mule.extension.jsonlogger.JsonLogger category"
+      },
+      "note": "This field is mandatory. DON'T REMOVE"
+    }
+  }
+}

--- a/json-logger/src/main/resources/schema/loggerProcessorError.json
+++ b/json-logger/src/main/resources/schema/loggerProcessorError.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Definition for fields used in the logger message processor",
+  "type": "object",
+  "properties": {
+    "correlationId": {
+      "type": "string",
+      "sdk": {
+        "default": "#[correlationId]",
+        "placement": {
+          "tab": "Advanced"
+        }
+      }
+    },
+    "message": {
+      "type": "string",
+      "sdk": {
+        "example": "Add a log message",
+        "required": true,
+        "summary": "Message to be logged"
+      }
+    },
+    "content": {
+      "type": "string",
+      "javaType": "org.mule.runtime.extension.api.runtime.parameter.ParameterResolver<org.mule.runtime.api.metadata.TypedValue<java.io.InputStream>>",
+      "sdk": {
+        "default": "#[import modules::JSONLoggerModule output application/json ---\n{\n    payload: JSONLoggerModule::stringifyNonJSON(payload) \n}]",
+        "summary": "NOTE: Writing the entire payload every time across your application can cause serious performance issues",
+        "required": false,
+        "isContent": true
+      }
+    },
+    "category": {
+      "type": "string",
+      "sdk": {
+        "required": false,
+        "summary": "If not set, by default will log to the org.mule.extension.jsonlogger.JsonLogger category"
+      },
+      "note": "This field is mandatory. DON'T REMOVE"
+    }
+  }
+}

--- a/json-logger/src/main/resources/schema/loggerProcessorFlow.json
+++ b/json-logger/src/main/resources/schema/loggerProcessorFlow.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Definition for fields used in the logger message processor",
+  "type": "object",
+  "properties": {
+    "correlationId": {
+      "type": "string",
+      "sdk": {
+        "default": "#[correlationId]",
+        "placement": {
+          "tab": "Advanced"
+        }
+      }
+    },
+    "message": {
+      "type": "string",
+      "sdk": {
+        "example": "Add a log message",
+        "required": true,
+        "summary": "Message to be logged"
+      }
+    },
+    "content": {
+      "type": "string",
+      "javaType": "org.mule.runtime.extension.api.runtime.parameter.ParameterResolver<org.mule.runtime.api.metadata.TypedValue<java.io.InputStream>>",
+      "sdk": {
+        "default": "#[import modules::JSONLoggerModule output application/json ---\n{\n    payload: JSONLoggerModule::stringifyNonJSON(payload) \n}]",
+        "summary": "NOTE: Writing the entire payload every time across your application can cause serious performance issues",
+        "required": false,
+        "isContent": true
+      }
+    },
+    "priority": {
+      "type": "string",
+      "javaType": "org.mule.extension.jsonlogger.api.pojos.FlowPriority",
+      "enum": [
+        "DEBUG",
+        "TRACE",
+        "INFO",
+        "WARN"
+      ],
+      "sdk": {
+        "default": "INFO",
+        "summary": "Logger priority"
+      },
+      "note": "This field is mandatory. DON'T REMOVE"
+    },
+    "category": {
+      "type": "string",
+      "sdk": {
+        "required": false,
+        "summary": "If not set, by default will log to the org.mule.extension.jsonlogger.JsonLogger category"
+      },
+      "note": "This field is mandatory. DON'T REMOVE"
+    }
+  }
+}

--- a/json-logger/src/main/resources/schema/loggerProcessorStart.json
+++ b/json-logger/src/main/resources/schema/loggerProcessorStart.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Definition for fields used in the logger message processor",
+  "type": "object",
+  "properties": {
+    "correlationId": {
+      "type": "string",
+      "sdk": {
+        "default": "#[correlationId]",
+        "placement": {
+          "tab": "Advanced"
+        }
+      }
+    },
+    "message": {
+      "type": "string",
+      "sdk": {
+        "example": "Add a log message",
+        "required": false,
+        "summary": "Message to be logged"
+      }
+    },
+    "content": {
+      "type": "string",
+      "javaType": "org.mule.runtime.extension.api.runtime.parameter.ParameterResolver<org.mule.runtime.api.metadata.TypedValue<java.io.InputStream>>",
+      "sdk": {
+        "default": "#[import modules::JSONLoggerModule output application/json ---\n{\n    payload: JSONLoggerModule::stringifyNonJSON(payload) \n}]",
+        "summary": "NOTE: Writing the entire payload every time across your application can cause serious performance issues",
+        "required": false,
+        "isContent": true
+      }
+    },
+    "category": {
+      "type": "string",
+      "sdk": {
+        "required": false,
+        "summary": "If not set, by default will log to the org.mule.extension.jsonlogger.JsonLogger category"
+      },
+      "note": "This field is mandatory. DON'T REMOVE"
+    }
+  }
+}


### PR DESCRIPTION
This PR implements https://github.com/mulesoft-consulting/json-logger/issues/23 from the old repository.

Here is the text of that issue:

Goal:  Reduce the changes required by developers when using the logger.  This will make the JSON logger easier to use and more importantly easier to use correctly.  It will also make the flows that use the JSON logger easier to read and understand without having to view the logger properties.

Approach:  Add new JSON Logger operations for each tracepoint each with default settings appropriate to that tracepoint.  This will favor convention over configuration.  The current fully configurable logger should be left in place so that the JSON logger is still useful when the convention is not appropriate.

These defaults affect three areas, the tracepoint, the priority, and the display name.

For example, to add a “start” logger the developer has to set the TracePoint to START, the priority to INFO, and update the Display Name to “Log start”.  

By having an operation named “Log start” with the appropriate defaults, the developer can just drag the logger into the flow with no configuration required.

Other loggers, such as before and after would have a reduced set of options with the defaults as the typical usage.

Finally, message should be optional where the tracepoint provides enough contextual information.

Here are the new operations and their defaults;

```
Operation       TracePoint         Priority   Message
-------
Log start       START              INFO       Optional
-------
Log end         END                INFO       Optional
-------
Log before      BEFORE_TRANSFORM   INFO       Optional
                * BEFORE_REQUEST   * DEBUG
                                   TRACE
-------
Log after       AFTER_TRANSFORM    INFO       Optional
                * AFTER_REQUEST    * DEBUG
                                   TRACE
-------
Log error       EXCEPTION          ERROR      Required 
-------
Log flow        FLOW               WARN       Required
                                   * INFO
                                   DEBUG
                                   TRACE
```


NOTE:  I had to use “Log error” instead of “Log exception” for the operation name log-exception conflicts with the logException attribute of the on-error element.